### PR TITLE
Fix timer positioning on large screens

### DIFF
--- a/index.html
+++ b/index.html
@@ -67,7 +67,12 @@ section{padding:80px 20px;}
   background:radial-gradient(circle at 30% 30%,#FFF 0%,var(--accent-dark) 120%);
   box-shadow:0 4px 8px var(--shadow),inset 0 1px 2px var(--highlight);
   display:grid;place-items:center;color:#fff;font-size:1rem;}
-@media(min-width:768px){.hero .timer-bar{position:absolute;top:30px;right:40px;}}
+@media(min-width:768px){
+  .hero .timer-bar{position:absolute;top:30px;right:40px;}
+}
+@media(min-width:1024px){
+  .hero .timer-bar{top:auto;bottom:40px;}
+}
 
 /* === SOCIAL PROOF ==================================================== */
 .testi{display:grid;gap:30px;}


### PR DESCRIPTION
## Summary
- update CSS so the timer bar sits at the bottom on screens wider than 1024px

## Testing
- `none` (no tests in repo)